### PR TITLE
Feature/copy assets fix

### DIFF
--- a/lib/src/main.js
+++ b/lib/src/main.js
@@ -4,6 +4,7 @@ const React = require('react');
 const opener = require('opener');
 const render = require('react-dom/server').renderToStaticMarkup;
 const MainHTML = require('./main-html');
+const pkg = require('../package.json');
 
 const distDir = path.join(__dirname, '..', 'dist');
 const inlineAssetsDir = path.join(distDir, 'assets', 'inline');
@@ -85,15 +86,33 @@ function getAssets() {
 /**
  * Copy the report assets to the report dir
  *
+ * This function follows the below logic to determine whether or not to copy the assets
+ * - Assets folder does not exist -> copy assets
+ * - Assets folder exists -> load the css asset to inspect the banner
+ * - Error loading css file -> copy assets
+ * - Read the package version from the css asset
+ * - Asset version is not found -> copy assets
+ * - Asset version differs from current version -> copy assets
+ *
  * @param {Object} opts
  * @returns {Object}
  */
 
 function copyAssets(opts) {
-  // Copy the assets to the report location if they don't exist
   const assetsDir = path.join(opts.reportDir, 'assets');
-  if (!fs.existsSync(assetsDir)) {
+  const assetsExist = fs.existsSync(assetsDir);
+  if (!assetsExist) {
     fs.copySync(externalAssetsDir, assetsDir);
+  } else {
+    try {
+      const appCss = loadFile(path.join(assetsDir, 'app.css'));
+      const appCssVersion = /\d+\.\d+\.\d+/.exec(appCss);
+      if (!appCssVersion || appCssVersion[0] !== pkg.version) {
+        fs.copySync(externalAssetsDir, assetsDir);
+      }
+    } catch (e) {
+      fs.copySync(externalAssetsDir, assetsDir);
+    }
   }
 }
 

--- a/webpack/base.config.js
+++ b/webpack/base.config.js
@@ -1,6 +1,7 @@
 const path = require('path');
 const webpack = require('webpack');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
+const pkg = require('../package.json');
 
 const env = (!!process.env.BABEL_ENV && process.env.BABEL_ENV) ||
           (!!process.env.NODE_ENV && process.env.NODE_ENV) ||
@@ -12,7 +13,8 @@ const devtool = isDev ? 'source-map' : '';
 
 const plugins = [
   new ExtractTextPlugin('[name].css', { allChunks: true }),
-  new webpack.optimize.OccurrenceOrderPlugin()
+  new webpack.optimize.OccurrenceOrderPlugin(),
+  new webpack.BannerPlugin(`mochawesome-report-generator ${pkg.version} | https://github.com/adamgruber/mochawesome-report-generator`)
 ];
 
 if (env === 'production') {


### PR DESCRIPTION
Fixes an issue where if the mochawesome assets already exist and you have upgraded mochawesome, the new assets would not be copied into the test report folder.

Related to https://github.com/adamgruber/mochawesome/issues/138