### PR TITLE
support rendering context with undefined/null value

### DIFF
--- a/src/components/test/context.jsx
+++ b/src/components/test/context.jsx
@@ -64,9 +64,9 @@ class TestContext extends Component {
     }
 
     // Default
-    const val = isString(content) ? content : JSON.stringify(content, null, 2);
+    const code = isString(content) ? content : JSON.stringify(content, null, 2);
     return (
-      <CodeSnippet className={ cx('code-snippet') } code={ val } highlight={ highlight } />
+      <CodeSnippet className={ cx('code-snippet') } code={ code } highlight={ highlight } />
     );
   }
 
@@ -89,17 +89,12 @@ class TestContext extends Component {
 
     // Context is an object with title and value
     const { title, value } = ctx;
-    /* istanbul ignore else */
-    if (value) {
-      return (
-        <div { ...containerProps } >
-          <h4 className={ cx('context-item-title') }>{ title }:</h4>
-          { this.renderContextContent(value, title, true) }
-        </div>
-      );
-    }
-
-    return false;
+    return (
+      <div { ...containerProps } >
+        <h4 className={ cx('context-item-title') }>{ title }:</h4>
+        { this.renderContextContent(value, title, true) }
+      </div>
+    );
   }
 
   render() {

--- a/test/spec/components/test/code-snippet.test.jsx
+++ b/test/spec/components/test/code-snippet.test.jsx
@@ -68,7 +68,7 @@ describe('<CodeSnippet />', () => {
 
   it('does not render when code is not passed', () => {
     const wrapper = getInstance({});
-    expect(wrapper).to.be.blank();
+    expect(wrapper.find('code')).to.have.lengthOf(0);
   });
 
   it('calls shouldComponentUpdate', () => {

--- a/test/spec/components/test/context.test.jsx
+++ b/test/spec/components/test/context.test.jsx
@@ -14,23 +14,24 @@ describe('<TestContext />', () => {
     return {
       wrapper,
       ctx: wrapper.find(TestContext),
-      ctxItems: wrapper.find('.context-item'),
+      ctxItems: wrapper.find('.test-context-item'),
       img: wrapper.find('.test-image-link'),
       link: wrapper.find('.test-text-link'),
       snippet: wrapper.find(CodeSnippet)
     };
   };
 
-  it('renders no context', () => {
+  it('renders context when value is undefined', () => {
     const context = {
-      title: 'sample context'
+      title: 'sample context',
+      value: 'undefined'
     };
     const { wrapper, ctxItems } = getInstance({
       context: JSON.stringify(context),
       className: 'test'
     });
-    expect(wrapper).to.be.blank;
-    expect(ctxItems).to.have.lengthOf(0);
+    expect(wrapper).to.have.className('test');
+    expect(ctxItems).to.have.lengthOf(1);
   });
 
   it('renders context with string', () => {


### PR DESCRIPTION
Supplement to https://github.com/adamgruber/mochawesome/pull/156

If context is added as an object and `value` is `null` or `undefined`, it will still be displayed in the report.