### PR TITLE
Fix error-message placement

### DIFF
--- a/src/components/test/test.jsx
+++ b/src/components/test/test.jsx
@@ -92,10 +92,10 @@ class Test extends React.Component {
             { !isHook && <Duration className={ cx('duration') } timer={ duration } /> }
             { !isHook && <Icon name='timer' className={ cx('duration-icon', speed) } size={ 18 } /> }
           </div>
+          { !!err.name && !!err.message && (
+            <p className={ cx('error-message') }>{ `${err.name}: ${err.message}` }</p>
+          ) }
         </header>
-        { !!err.name && !!err.message && (
-          <p className={ cx('error-message') }>{ `${err.name}: ${err.message}` }</p>
-        ) }
         <div className={ cx('body') }>
           { <CodeSnippet className={ cx('code-snippet') } code={ err.estack } highlight={ false } label='Stack Trace' /> }
           { <CodeSnippet className={ cx('code-snippet') } code={ err.diff } lang='diff' label='Diff' /> }


### PR DESCRIPTION
There's a misplacement of the `.error-message` `<p>` tag in `test.jsx`, that causes the AssertionError message to be misaligned:

**Before:**

![screen shot 2017-06-12 at 4 41 35 pm](https://user-images.githubusercontent.com/9884746/27025808-5cf8eb48-4f8e-11e7-89d5-8b9a329a4f66.png)

**After:**

![screen shot 2017-06-12 at 4 41 54 pm](https://user-images.githubusercontent.com/9884746/27025811-5f8a793a-4f8e-11e7-9650-7ec65f68f438.png)

I'm not sure exactly which npm script to use to build for production, as `npm run dist` seems to create a large number of differences in `dist/assets/external/app.js` and `dist/assets/inline/app.js`.

Do let me know how to build it for production and I'll add another commit/force push to this branch.