### PR TITLE
Feature/hooks display option

### DIFF
--- a/lib/src/options.js
+++ b/lib/src/options.js
@@ -19,6 +19,12 @@ const isFunction = require('lodash.isfunction');
  *                                      Accepts any format string that dateformat can handle.
  *                                      See https://github.com/felixge/node-dateformat
  *                                      Defaults to 'isoDateTime' when no format is specified
+ * @property {string}  showHooks        Determines when hooks should display in the report
+ *                                      Choices:
+ *                                       - always: display all hooks
+ *                                       - never: do not display hooks
+ *                                       - failed: display only failed hooks (default)
+ *                                       - context: display only hooks with context
  * @property {boolean} dev              Enable dev mode in the report,
  *                                      asssets loaded via webpack (default: false)
  */
@@ -86,6 +92,11 @@ const yargsOptions = {
     default: false,
     describe: 'Append timestamp in specified format to filename',
     string: true
+  },
+  showHooks: {
+    default: 'failed',
+    describe: 'Display hooks in the report',
+    choices: [ 'always', 'never', 'failed', 'context' ]
   },
   dev: {
     default: false,

--- a/src/components/nav-menu/nav-menu.jsx
+++ b/src/components/nav-menu/nav-menu.jsx
@@ -17,12 +17,11 @@ const NavMenu = props => {
   const navItemProps = { showPassed, showFailed, showPending, showSkipped };
   const closeSideNav = () => (reportStore.closeSideNav());
   const reportDate = moment(end).format('dddd, MMMM D YYYY, hh:mma');
-  const showHooksOptions = [
-    { title: 'Always', value: 'always' },
-    { title: 'Never', value: 'never' },
-    { title: 'Failed', value: 'failed' }
-  ];
-  const showHooksSelected = find(showHooksOptions, { value: showHooks });
+  const showHooksOpts = reportStore.showHooksOptions.map(opt => ({
+    title: `${opt.charAt(0).toUpperCase()}${opt.slice(1)}`,
+    value: opt
+  }));
+  const showHooksSelected = find(showHooksOpts, { value: showHooks });
   return (
     <div className={ cx('wrap', { open: sideNavOpen }) }>
       <div onClick={ closeSideNav } className={ cx('overlay') } />
@@ -76,7 +75,7 @@ const NavMenu = props => {
             label='Show Hooks'
             labelClassName={ cx('control-label') }
             selected={ showHooksSelected }
-            selections={ showHooksOptions }
+            selections={ showHooksOpts }
             onSelect={ item => reportStore.setShowHooks(item.value) } />
         </div>
         <div className={ cx('section') }>

--- a/src/components/test/test.css
+++ b/src/components/test/test.css
@@ -158,7 +158,7 @@
 
 .error-message {
   font-size: 12px;
-  margin: 0 0 10px 13px;
+  margin: 0 16px 10px 13px;
   color: var(--red500);
 }
 

--- a/test/spec/components/nav-menu/nav-menu.test.jsx
+++ b/test/spec/components/nav-menu/nav-menu.test.jsx
@@ -21,7 +21,8 @@ const NavMenu = proxyquire('components/nav-menu/nav-menu', {
   '../../js/reportStore': {
     closeSideNav: closeSideNavSpy,
     toggleFilter: toggleFilterSpy,
-    setShowHooks: setShowHooksSpy
+    setShowHooks: setShowHooksSpy,
+    showHooksOptions: [ 'always', 'never' ]
   }
 }).default;
 

--- a/test/spec/lib/main.test.js
+++ b/test/spec/lib/main.test.js
@@ -44,7 +44,8 @@ const baseOpts = {
   enableCode: true,
   overwrite: true,
   timestamp: false,
-  dev: false
+  dev: false,
+  showHooks: 'failed'
 };
 
 let opts;
@@ -316,7 +317,8 @@ describe('lib/main', () => {
           overwrite: true,
           timestamp: false,
           ts: false,
-          dev: false
+          dev: false,
+          showHooks: 'failed'
         });
     });
   });

--- a/test/spec/lib/options.test.js
+++ b/test/spec/lib/options.test.js
@@ -17,7 +17,8 @@ const expectedOptions = {
   overwrite: true,
   timestamp: false,
   ts: false,
-  dev: false
+  dev: false,
+  showHooks: 'failed'
 };
 
 describe('options', () => {

--- a/test/spec/reportStore.test.js
+++ b/test/spec/reportStore.test.js
@@ -22,21 +22,51 @@ describe('ReportStore', () => {
     });
   });
 
-  it('sets initial data', () => {
-    store.setInitialData({
-      data: testData,
-      config: {
-        enableCharts: true,
-        dev: true
-      }
+  describe('setInitialData', () => {
+    it('without config options', () => {
+      store.setInitialData({
+        data: testData,
+        config: {}
+      });
+      expect(store).to.have.property('data', testData);
+      expect(store).to.have.property('reportTitle', undefined);
+      expect(store).to.have.property('stats', testData.stats);
+      expect(store).to.have.deep.property('allSuites[0]', testData.suites);
+      expect(store).to.have.deep.property('stats', testData.stats);
+      expect(store).to.have.property('enableChart', false);
+      expect(store).to.have.property('devMode', false);
+      expect(store).to.have.property('showHooks', 'failed');
     });
-    expect(store).to.have.property('data', testData);
-    expect(store).to.have.property('reportTitle', undefined);
-    expect(store).to.have.property('stats', testData.stats);
-    expect(store).to.have.deep.property('allSuites[0]', testData.suites);
-    expect(store).to.have.deep.property('stats', testData.stats);
-    expect(store).to.have.property('enableChart', true);
-    expect(store).to.have.property('devMode', true);
+
+    it('with config options', () => {
+      store.setInitialData({
+        data: testData,
+        config: {
+          enableCharts: true,
+          dev: true,
+          showHooks: 'context'
+        }
+      });
+      expect(store).to.have.property('data', testData);
+      expect(store).to.have.property('reportTitle', undefined);
+      expect(store).to.have.property('stats', testData.stats);
+      expect(store).to.have.deep.property('allSuites[0]', testData.suites);
+      expect(store).to.have.deep.property('stats', testData.stats);
+      expect(store).to.have.property('enableChart', true);
+      expect(store).to.have.property('devMode', true);
+      expect(store).to.have.property('showHooks', 'context');
+    });
+
+
+    it('with invalid config options', () => {
+      store.setInitialData({
+        data: testData,
+        config: {
+          showHooks: 'sometimes'
+        }
+      });
+      expect(store).to.have.property('showHooks', 'failed');
+    });
   });
 
   describe('Computed Properties', () => {


### PR DESCRIPTION
- Adds ability to set display of hooks via config option `showHooks` 
- Adds new display option `context` to show only hooks that contain context added via `addContext()`

https://github.com/adamgruber/mochawesome/issues/165