### PR TITLE
Implement base64 images

### DIFF
--- a/src/components/test/context.jsx
+++ b/src/components/test/context.jsx
@@ -7,6 +7,7 @@ import styles from './test.css';
 
 const cx = classNames.bind(styles);
 
+const base64RegEx = /^data:image\/([a-zA-Z]*);base64,([^"]*)$/i;
 const imgRegEx = /(?:png|jpe?g|gif)$/i;
 const protocolRegEx = /^(?:(?:https?|ftp):\/\/)/i;
 const urlRegEx = /^(?:(?:https?|ftp):\/\/)?(?:\S+(?::\S*)?@)?(?:(?!(?:10|127)(?:\.\d{1,3}){3})(?!(?:169\.254|192\.168)(?:\.\d{1,3}){2})(?!172\.(?:1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2})(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-z\u00a1-\uffff0-9]-*)*[a-z\u00a1-\uffff0-9]+)(?:\.(?:[a-z\u00a1-\uffff0-9]-*)*[a-z\u00a1-\uffff0-9]+)*(?:\.(?:[a-z\u00a1-\uffff]{2,}))\.?)(?::\d{2,5})?(?:[/?#]\S*)?$/ // eslint-disable-line
@@ -21,6 +22,13 @@ class TestContext extends Component {
       PropTypes.object,
       PropTypes.array
     ])
+  };
+
+  renderBase64 = (ctx, title) => {
+    const base64 = ctx;
+    return (
+      <img src={ base64 } className={ cx('image') } alt={ title } />
+    );
   };
 
   renderImage = (ctx, title) => {
@@ -53,6 +61,11 @@ class TestContext extends Component {
   }
 
   renderContextContent = (content, title, highlight = false) => {
+    // Base64
+    if (base64RegEx.test(content)) {
+      return this.renderBase64(content, title);
+    }
+
     // Images
     if (imgRegEx.test(content)) {
       return this.renderImage(content, title);

--- a/test/spec/components/test/context.test.jsx
+++ b/test/spec/components/test/context.test.jsx
@@ -15,7 +15,7 @@ describe('<TestContext />', () => {
       wrapper,
       ctx: wrapper.find(TestContext),
       ctxItems: wrapper.find('.test-context-item'),
-      img: wrapper.find('.test-image-link'),
+      img: wrapper.find('.test-image'),
       link: wrapper.find('.test-text-link'),
       snippet: wrapper.find(CodeSnippet)
     };
@@ -80,6 +80,17 @@ describe('<TestContext />', () => {
 
     it('renders local image', () => {
       const context = '/testimage.png';
+      const { wrapper, snippet, img } = getInstance({
+        context: JSON.stringify(context),
+        className: 'test'
+      });
+      expect(wrapper).to.have.className('test');
+      expect(snippet).to.have.lengthOf(0);
+      expect(img).to.have.lengthOf(1);
+    });
+
+    it('renders base64 image', () => {
+      const context = 'data:image/jpeg;base64,/9j/4AAQSkZJRgABAgAAZABkAAD/7AARRHVja3kAAQAEAAAAPAAA/+4AJkFkb2JlAGTAAAAAAQMAFQQDBgoNAAABywAAAgsAAAJpAAACyf/bAIQABgQEBAUEBgUFBgkGBQYJCwgGBggLDAoKCwoKDBAMDAwMDAwQDA4PEA8ODBMTFBQTExwbGxscHx8fHx8fHx8fHwEHBwcNDA0YEBAYGhURFRofHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8f/8IAEQgAEAAQAwERAAIRAQMRAf/EAJQAAQEBAAAAAAAAAAAAAAAAAAMFBwEAAwEAAAAAAAAAAAAAAAAAAAEDAhAAAQUBAQAAAAAAAAAAAAAAAgABAwQFESARAAIBAwIHAAAAAAAAAAAAAAERAgAhMRIDQWGRocEiIxIBAAAAAAAAAAAAAAAAAAAAIBMBAAMAAQQDAQAAAAAAAAAAAQARITHwQVGBYXGR4f/aAAwDAQACEQMRAAAB0UlMciEJn//aAAgBAQABBQK5bGtFn6pWi2K12wWTRkjb/9oACAECAAEFAvH/2gAIAQMAAQUCIuIJOqRndRiv/9oACAECAgY/Ah//2gAIAQMCBj8CH//aAAgBAQEGPwLWQzwHepfNbcUNfM4tUIbA9QL4AvnxTlAxacpWJReOlf/aAAgBAQMBPyHZDveuCyu4B4lz2lDKto2ca5uclPK0aoq32x8xgTSLeSgbyzT65n//2gAIAQIDAT8hlQjP/9oACAEDAwE/IaE9GcZFJ//aAAwDAQACEQMRAAAQ5F//2gAIAQEDAT8Q1oowKccI3KTdAWkPLw2ssIrwKYUzuJoUJsIHOCoG23ISlja+rU9QvCx//9oACAECAwE/EAuNIiKf/9oACAEDAwE/ECujJzHf7iwHOv5NhK+8efH50z//2Q==';
       const { wrapper, snippet, img } = getInstance({
         context: JSON.stringify(context),
         className: 'test'


### PR DESCRIPTION
Use base64 images. It's quite useful as selenium screenshot images can be generated on the fly.

https://github.com/adamgruber/mochawesome/issues/171

What I did:

Built another RegEx for detecting a base64 image. Afterwards, I used the appropriate renderer to display the image.

Result:

<img width="1280" alt="screen shot 2017-07-08 at 12 22 16 pm" src="https://user-images.githubusercontent.com/1214868/27988509-3cfcce3c-63d8-11e7-9a25-81c208e981ce.png">
