### PR TITLE
Feature/html option

### DIFF
--- a/lib/src/main.js
+++ b/lib/src/main.js
@@ -119,6 +119,7 @@ function getOptions(opts) {
   if (mergedOptions.saveJson) {
     mergedOptions.jsonFile = `${getFilename(mergedOptions)}.json`;
   }
+
   mergedOptions.htmlFile = `${getFilename(mergedOptions)}.html`;
   return mergedOptions;
 }
@@ -233,16 +234,27 @@ function prepare(reportData, opts) {
  */
 function create(data, opts) {
   const { html, reportOptions } = prepare(data, opts);
-  const { saveJson, autoOpen, overwrite, jsonFile, htmlFile } = reportOptions;
+  const {
+    saveJson,
+    saveHtml,
+    autoOpen,
+    overwrite,
+    jsonFile,
+    htmlFile
+  } = reportOptions;
 
-  const savePromises = [
-    saveFile(htmlFile, html, overwrite)
-      .then(savedHtml => (autoOpen && openFile(savedHtml)) || savedHtml)
-  ];
+  const savePromises = [];
 
-  if (saveJson) {
-    savePromises.push(saveFile(jsonFile, JSON.stringify(data, null, 2), overwrite));
-  }
+  savePromises.push(saveHtml !== false
+    ? saveFile(htmlFile, html, overwrite)
+        .then(savedHtml => (autoOpen && openFile(savedHtml)) || savedHtml)
+    : null
+  );
+
+  savePromises.push(saveJson
+    ? saveFile(jsonFile, JSON.stringify(data, null, 2), overwrite)
+    : null
+  );
 
   return Promise.all(savePromises);
 }

--- a/lib/src/options.js
+++ b/lib/src/options.js
@@ -26,6 +26,7 @@ const isFunction = require('lodash.isfunction');
  *                                       - failed: display only failed hooks (default)
  *                                       - context: display only hooks with context
  * @property {boolean} saveJson         Should report data be saved to JSON file (default: false)
+ * @property {boolean} saveHtml         Should report be saved to HTML file (default: true)
  * @property {boolean} dev              Enable dev mode in the report,
  *                                      asssets loaded via webpack (default: false)
  */
@@ -102,6 +103,11 @@ export const yargsOptions = {
   saveJson: {
     default: false,
     describe: 'Save report data to JSON file',
+    boolean: true
+  },
+  saveHtml: {
+    default: true,
+    describe: 'Save report to HTML file',
     boolean: true
   },
   dev: {

--- a/test/spec/lib/main.test.js
+++ b/test/spec/lib/main.test.js
@@ -52,14 +52,25 @@ beforeEach(() => {
 
 describe('lib/main', () => {
   describe('create', () => {
-    it('saves report', () => {
+    it('saves only html', () => {
       const expectedHtmlFile = path.resolve(process.cwd(), 'test', 'test.html');
       outputFileStub.resolves(expectedHtmlFile);
       const promise = mareport.create(testData, opts);
-      return expect(promise).to.become([ expectedHtmlFile ]);
+      return expect(promise).to.become([ expectedHtmlFile, null ]);
     });
 
-    it('saves report and json', () => {
+    it('saves only json', () => {
+      opts.saveHtml = false;
+      opts.saveJson = true;
+      const expectedJsonFile = path.resolve(process.cwd(), 'test', 'test.json');
+      outputFileStub
+        .onCall(0).resolves('')
+        .onCall(1).resolves(expectedJsonFile);
+      const promise = mareport.create(testData, opts);
+      return expect(promise).to.become([ null, expectedJsonFile ]);
+    });
+
+    it('saves html and json', () => {
       opts.saveJson = true;
       const expectedHtmlFile = path.resolve(process.cwd(), 'test', 'test.html');
       const expectedJsonFile = path.resolve(process.cwd(), 'test', 'test.json');
@@ -68,6 +79,13 @@ describe('lib/main', () => {
         .onCall(1).resolves(expectedJsonFile);
       const promise = mareport.create(testData, opts);
       return expect(promise).to.become([ expectedHtmlFile, expectedJsonFile ]);
+    });
+
+    it('does NOT save report', () => {
+      opts.saveHtml = false;
+      outputFileStub.resolves('');
+      const promise = mareport.create(testData, opts);
+      return expect(promise).to.become([ null, null ]);
     });
 
     it('with autoOpen', () => {

--- a/test/spec/lib/options.test.js
+++ b/test/spec/lib/options.test.js
@@ -17,6 +17,7 @@ const expectedOptions = {
   overwrite: true,
   timestamp: false,
   saveJson: false,
+  saveHtml: true,
   ts: false,
   dev: false,
   showHooks: 'failed'


### PR DESCRIPTION
Implements `saveHtml` option. This option is `true` by default and will not be exposed in the documentation. It exists to support the mochawesome reporter should a user want to use it to generate only the JSON output.

https://github.com/adamgruber/mochawesome/issues/173