### PR TITLE
Fix issue where full test titles cannot be seen when truncation occurs.

### DIFF
--- a/src/components/test/test.css
+++ b/src/components/test/test.css
@@ -53,6 +53,12 @@
   @nest .hook & {
     color: var(--black54);
   }
+
+  @nest .expanded & {
+    line-height: 1.5;
+    padding-top: 3px;
+    white-space: normal;
+  }
 }
 
 .icon {

--- a/src/components/test/test.jsx
+++ b/src/components/test/test.jsx
@@ -85,7 +85,7 @@ class Test extends React.Component {
         <header className={ cx('header') } onClick={ this.toggleExpandedState }>
           <div className={ cx('title-wrap') }>
             { testIcon() }
-            <h4 className={ cx('title') }>{ title }</h4>
+            <h4 className={ cx('title') } title={ title }>{ title }</h4>
           </div>
           <div className={ cx('info') }>
             { !!context && <Icon name='chat_bubble_outline' className={ cx('context-icon') } size={ 18 } /> }


### PR DESCRIPTION
https://github.com/adamgruber/mochawesome-report-generator/issues/65
- Add title attribute so full titles can be seen in title tooltip
- Show full test titles when the test is expanded