### PR TITLE
Support directory arguments in the CLI

### DIFF
--- a/bin/src/types.js
+++ b/bin/src/types.js
@@ -5,13 +5,14 @@ const PercentClass = t.enums.of([ 'success', 'warning', 'danger' ], 'PercentClas
 const TestState = t.enums.of([ 'passed', 'failed' ], 'TestState');
 const TestSpeed = t.enums.of([ 'slow', 'medium', 'fast' ], 'TestSpeed');
 const DateString = t.refinement(t.String, isISO8601, 'DateString');
+const Duration = t.maybe(t.Integer);
 const Uuid = t.refinement(t.String, isUUID, 'UUID');
 
 const Test = t.struct({
   title: t.String,
   fullTitle: t.String,
   timedOut: t.Boolean,
-  duration: t.Integer,
+  duration: Duration,
   state: t.maybe(TestState),
   speed: t.maybe(TestSpeed),
   pass: t.Boolean,
@@ -43,7 +44,7 @@ Suite.define(t.struct({
   failures: t.list(Uuid),
   pending: t.list(Uuid),
   skipped: t.list(Uuid),
-  duration: t.Integer,
+  duration: Duration,
   rootEmpty: t.maybe(t.Boolean)
 }));
 
@@ -56,7 +57,7 @@ const TestReport = t.struct({
     failures: t.Integer,
     start: DateString,
     end: DateString,
-    duration: t.Integer,
+    duration: Duration,
     testsRegistered: t.Integer,
     passPercent: t.Number,
     pendingPercent: t.Number,

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "chai-enzyme": "^1.0.0-beta.0",
     "chart.js": "^2.3.0",
     "classnames": "^2.2.5",
-    "cross-env": "^5.1.1",
+    "cross-env": "5.1.1",
     "css-loader": "^0.28.0",
     "css-modules-require-hook": "^4.0.5",
     "enzyme": "^3.1.0",

--- a/test/sample-data/sub/single.json
+++ b/test/sample-data/sub/single.json
@@ -1,0 +1,115 @@
+{
+  "stats": {
+    "suites": 1,
+    "tests": 1,
+    "passes": 0,
+    "pending": 0,
+    "failures": 1,
+    "start": "2017-06-05T12:27:21.360Z",
+    "end": "2017-06-05T12:27:21.376Z",
+    "duration": 16,
+    "testsRegistered": 1,
+    "passPercent": 0,
+    "pendingPercent": 0,
+    "other": 0,
+    "hasOther": false,
+    "skipped": 0,
+    "hasSkipped": false,
+    "passPercentClass": "danger",
+    "pendingPercentClass": "danger"
+  },
+  "suites": {
+    "title": "",
+    "suites": [
+      {
+        "title": "Main Suite",
+        "suites": [],
+        "tests": [
+          {
+            "title": "should be false",
+            "fullTitle": "Main Suite should be false",
+            "timedOut": false,
+            "duration": 4,
+            "state": "failed",
+            "pass": false,
+            "fail": true,
+            "pending": false,
+            "code": "// true.should.eql(bool);\nexp.should.eql({\n  foo: true,\n  bar: true,\n  baz: 1\n});\nshouldAddContext && addContext(this, 'context');",
+            "err": {
+              "operator": "to equal",
+              "expected": "{\n  \"bar\": true\n  \"baz\": 1\n  \"foo\": true\n}",
+              "details": "at bar, A has false and B has true",
+              "showDiff": true,
+              "actual": "{\n  \"bar\": false\n  \"baz\": 1\n  \"foo\": true\n}",
+              "negate": false,
+              "assertion": {
+                "obj": {
+                  "foo": true,
+                  "bar": false,
+                  "baz": 1
+                },
+                "anyOne": false,
+                "negate": false,
+                "params": {
+                  "operator": "to equal",
+                  "expected": {
+                    "foo": true,
+                    "bar": true,
+                    "baz": 1
+                  },
+                  "details": "at bar, A has false and B has true",
+                  "showDiff": true,
+                  "actual": {
+                    "foo": true,
+                    "bar": false,
+                    "baz": 1
+                  },
+                  "negate": false,
+                  "assertion": "[Circular ~.suites.suites.0.tests.0.err.assertion]"
+                },
+                "light": false
+              },
+              "_message": "expected Object { foo: true, bar: false, baz: 1 } to equal Object { foo: true, bar: true, baz: 1 } (at bar, A has false and B has true)",
+              "generatedMessage": true,
+              "estack": "AssertionError: expected Object { foo: true, bar: false, baz: 1 } to equal Object { foo: true, bar: true, baz: 1 } (at bar, A has false and B has true)\n    at Assertion.fail (node_modules/should/cjs/should.js:258:17)\n    at Assertion.value (node_modules/should/cjs/should.js:335:19)\n    at Context.<anonymous> (helpers.js:26:20)",
+              "diff": " {\n-   \"bar\": false\n+   \"bar\": true\n   \"baz\": 1\n   \"foo\": true\n }\n"
+            },
+            "isRoot": false,
+            "uuid": "65ef9d51-2e7b-4155-9d46-af6ad7d0e2d4",
+            "parentUUID": "37685726-1c47-4e1f-a7d4-6c88ebf842f9",
+            "isHook": false,
+            "skipped": false
+          }
+        ],
+        "pending": [],
+        "root": false,
+        "_timeout": 2000,
+        "file": "/cases/test.js",
+        "uuid": "37685726-1c47-4e1f-a7d4-6c88ebf842f9",
+        "beforeHooks": [],
+        "afterHooks": [],
+        "fullFile": "/Users/adamgruber/Sites/ma-test/cases/test.js",
+        "passes": [],
+        "failures": ["65ef9d51-2e7b-4155-9d46-af6ad7d0e2d4"],
+        "skipped": [],
+        "duration": 4,
+        "rootEmpty": false
+      }
+    ],
+    "tests": [],
+    "pending": [],
+    "root": true,
+    "_timeout": 2000,
+    "uuid": "005cc237-6ddd-4da6-8b5c-e82c1ee5cfdc",
+    "beforeHooks": [],
+    "afterHooks": [],
+    "fullFile": "",
+    "file": "",
+    "passes": [],
+    "failures": [],
+    "skipped": [],
+    "duration": 0,
+    "rootEmpty": true
+  },
+  "copyrightYear": 2017
+}

--- a/test/spec/cli/cli-main.test.js
+++ b/test/spec/cli/cli-main.test.js
@@ -61,25 +61,23 @@ describe('bin/cli', () => {
     });
   });
 
-  describe('when file is a directory', () => {
-    it('should not create a report', () => {
-      const args = getArgs([ 'test/sample-data/' ]);
-      return expect(cli(args)).to.become([ {
-        filename: 'test/sample-data/',
-        data: undefined,
-        err: '  Directories are not supported (yet).'
-      } ]);
+  describe('when arg is a directory', () => {
+    beforeEach(() => {
+      createStub.onCall(0).resolves('mochawesome-report/single.html');
+    });
+
+    it('should create a report', () => {
+      const args = getArgs([ 'test/sample-data/sub' ]);
+      return expect(cli(args)).to.become([
+        'mochawesome-report/single.html'
+      ]);
     });
   });
 
   describe('when file is not JSON', () => {
     it('should not create a report', () => {
       const args = getArgs([ 'README.md' ]);
-      return expect(cli(args)).to.become([ {
-        filename: 'README.md',
-        data: undefined,
-        err: '  You must supply a valid JSON file.'
-      } ]);
+      return expect(cli(args)).to.become([]);
     });
   });
 


### PR DESCRIPTION
With this PR you can pass a directory as an argument to the CLI and it will recurse through looking for JSON files to process.

Note, the directory structure will be lost upon report creation and all reports will be created inside the report directory as defined by the `reportDir` option (or the default value if not provided).