### PR TITLE
Implement assetsDir option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # mochawesome-report-generator changelog
 
+## Unreleased
+### Added
+- New option: `assetsDir` - specify a custom location for the report assets (js/css)
+- CLI: Support directories as agruments
+- New options: `showPassed`, `showFailed`, `showPending`, `showSkipped` - set the default state of the report filters
+
+### Changed
+- Use a top-level `<Provider>` component to make the report store available to all components
+
 ## [3.0.1] / 2017-12-01
 No release is complete without a quick hotfix.
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Flag | Type | Default | Description
 -t, --reportTitle | string | mochawesome | Report title
 -p, --reportPageTitle | string | mochawesome-report | Browser title
 -i, --inline | boolean | false | Inline report assets (scripts, styles)
+--assetsDir | string | [cwd]/mochawesome-report/assets | Path to save report assets (js/css)
 --charts | boolean | true | Display Suite charts
 --code | boolean | true | Display test code
 --autoOpen | boolean | false | Automatically open the report

--- a/bin/src/cli.js
+++ b/bin/src/cli.js
@@ -5,7 +5,7 @@ const marge = require('./cli-main');
 
 // Setup yargs
 yargs
-  .usage('Usage: $0 [options] data_file [data_file2 ...]')
+  .usage('Usage: $0 [options] <data_file> [data_file2..]')
   .demand(1)
   .options(yargsOptions)
   .help('help')

--- a/lib/src/main-html.jsx
+++ b/lib/src/main-html.jsx
@@ -3,9 +3,9 @@ const React = require('react');
 const PropTypes = require('prop-types');
 
 function MainHTML(props) {
-  const { data, options, scripts, styles } = props;
-  const clientScript = options.dev ? 'http://localhost:8080/app.js' : 'assets/app.js';
-  const clientStyle = options.dev ? 'http://localhost:8080/app.css' : 'assets/app.css';
+  const { assetsDir, data, options, scripts, styles } = props;
+  const clientScript = options.dev ? 'http://localhost:8080/app.js' : `${assetsDir}/app.js`;
+  const clientStyle = options.dev ? 'http://localhost:8080/app.css' : `${assetsDir}/app.css`;
   return (
     <html lang='en'>
       <head>
@@ -28,6 +28,7 @@ function MainHTML(props) {
 }
 
 MainHTML.propTypes = {
+  assetsDir: PropTypes.string,
   data: PropTypes.string,
   options: PropTypes.object,
   scripts: PropTypes.string,

--- a/lib/src/main.js
+++ b/lib/src/main.js
@@ -153,8 +153,7 @@ function getAssets() {
  * @param {Object} opts Report options
  *
  */
-function copyAssets(opts) {
-  const assetsDir = path.join(opts.reportDir, 'assets');
+function copyAssets({ assetsDir }) {
   const assetsExist = fs.existsSync(assetsDir);
   if (!assetsExist) {
     fs.copySync(externalAssetsDir, assetsDir);
@@ -182,7 +181,10 @@ function copyAssets(opts) {
  * @return {string} Rendered HTML string
  */
 function renderHtml(data, reportOptions, styles, scripts) {
+  const { reportDir, assetsDir } = reportOptions;
+  const relativeAssetsDir = path.relative(reportDir, assetsDir);
   return render(React.createElement(MainHTML, {
+    assetsDir: relativeAssetsDir,
     data,
     options: reportOptions,
     styles,

--- a/lib/src/options.js
+++ b/lib/src/options.js
@@ -9,6 +9,7 @@ const isFunction = require('lodash.isfunction');
  * @property {string}  reportDir        Path to save report to (default: cwd/mochawesome-report)
  * @property {string}  reportTitle      Title to use on the report (default: mochawesome)
  * @property {string}  reportPageTitle  Title of the report document (default: mochawesome-report)
+ * @property {string}  assetsDir        Path to save report assets to (default: cwd/mochawesome-report/assets)
  * @property {boolean} inlineAssets     Should assets be inlined into HTML file (default: false)
  * @property {boolean} charts           Should charts be enabled (default: true)
  * @property {boolean} code             Should test code output be enabled (default: true)
@@ -51,9 +52,7 @@ export const yargsOptions = {
   },
   t: {
     alias: [ 'reportTitle' ],
-    default: function currentDir() {
-      return process.cwd().split(path.sep).pop();
-    },
+    default: () => process.cwd().split(path.sep).pop(),
     describe: 'Report title',
     string: true,
     requiresArg: true
@@ -70,6 +69,12 @@ export const yargsOptions = {
     default: false,
     describe: 'Inline report assets (styles, scripts)',
     boolean: true
+  },
+  assetsDir: {
+    describe: 'Path to save assets',
+    string: true,
+    normalize: true,
+    requiresArg: true
   },
   charts: {
     alias: [ 'enableCharts' ],
@@ -218,5 +223,11 @@ export const getMergedOptions = function (userOptions) {
       assignVal(optKey, userVal, defaultVal);
     }
   });
+
+  // Special handling for defining `assetsDir`
+  if (!mergedOptions.assetsDir) {
+    mergedOptions.assetsDir = path.join(mergedOptions.reportDir, 'assets');
+  }
+
   return mergedOptions;
 };

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "chai-enzyme": "^1.0.0-beta.0",
     "chart.js": "^2.3.0",
     "classnames": "^2.2.5",
-    "cross-env": "5.1.1",
+    "cross-env": "^5.1.3",
     "css-loader": "^0.28.0",
     "css-modules-require-hook": "^4.0.5",
     "enzyme": "^3.1.0",

--- a/test/spec/components/main.test.jsx
+++ b/test/spec/components/main.test.jsx
@@ -8,42 +8,43 @@ import Main from '../../../lib/src/main-html';
 chai.use(chaiEnzyme());
 
 const data = JSON.stringify({ testdata: 'test' });
-const reportPageTitle = 'test';
+
+const getInstance = props => shallow(<Main data={ data } { ...props } />);
 
 describe('<MainHTML />', () => {
-  it('sets correct script/style urls', () => {
-    const opts = {
-      options: {
-        reportPageTitle
-      }
+  let options;
+  let props;
+
+  beforeEach(() => {
+    options = {
+      reportPageTitle: 'test'
     };
-    const wrapper = shallow(<Main data={ data } { ...opts } />);
-    expect(wrapper.find('link')).to.have.attr('href', 'assets/app.css');
-    expect(wrapper.find('script')).to.have.attr('src', 'assets/app.js');
+    props = {
+      assetsDir: 'test/assets',
+      options
+    };
+  });
+
+  it('sets correct script/style urls', () => {
+    const wrapper = getInstance(props);
+    expect(wrapper.find('link')).to.have.attr('href', 'test/assets/app.css');
+    expect(wrapper.find('script')).to.have.attr('src', 'test/assets/app.js');
   });
 
   it('sets correct script/style urls for dev', () => {
-    const opts = {
-      options: {
-        reportPageTitle,
-        dev: true
-      }
-    };
-    const wrapper = shallow(<Main data={ data } { ...opts } />);
+    props.options.dev = true;
+    const wrapper = getInstance(props);
     expect(wrapper.find('link')).to.have.attr('href', 'http://localhost:8080/app.css');
     expect(wrapper.find('script')).to.have.attr('src', 'http://localhost:8080/app.js');
   });
 
   it('renders scripts/styles inline', () => {
-    const opts = {
-      options: {
-        reportPageTitle,
-        inlineAssets: true
-      },
+    const newProps = { ...props,
+      options: { ...options, inlineAssets: true },
       styles: 'body{display:block;}',
       scripts: 'function noop(){return;}'
     };
-    const wrapper = shallow(<Main data={ data } { ...opts } />);
+    const wrapper = getInstance(newProps);
     expect(wrapper.find('style'))
       .to.have.html('<style>body{display:block;}</style>');
     expect(wrapper.find('script'))

--- a/test/spec/lib/options.test.js
+++ b/test/spec/lib/options.test.js
@@ -7,6 +7,7 @@ const expectedOptions = {
   reportDir: 'mochawesome-report',
   reportTitle: process.cwd().split(path.sep).pop(),
   reportPageTitle: 'Mochawesome Report',
+  assetsDir: 'mochawesome-report/assets',
   inline: false,
   inlineAssets: false,
   charts: true,
@@ -39,6 +40,7 @@ describe('options', () => {
     beforeEach(() => {
       userOptions = {
         reportDir: 'userDir',
+        assetsDir: 'userDir/assets',
         inline: true,
         enableCode: false,
         dev: 'true',


### PR DESCRIPTION
This PR adds a new option, `assetsDir`, that will let you specify a custom location to save the report assets to.

https://github.com/adamgruber/mochawesome/issues/216