### PR TITLE
Chore/replace moment

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
   },
   "dependencies": {
     "chalk": "^2.3.0",
+    "date-fns": "^1.29.0",
     "dateformat": "^3.0.2",
     "fs-extra": "^4.0.2",
     "fsu": "^1.0.2",
@@ -133,7 +134,6 @@
     "mobx-react": "^4.0.0",
     "mobx-react-devtools": "^4.2.9",
     "mocha": "*",
-    "moment": "^2.15.1",
     "nodemon": "^1.11.0",
     "normalize.css": "^7.0.0",
     "nyc": "^11.4.0",

--- a/src/components/duration.jsx
+++ b/src/components/duration.jsx
@@ -1,7 +1,6 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import moment from 'moment';
 
 class Duration extends PureComponent {
   static propTypes = {
@@ -11,43 +10,56 @@ class Duration extends PureComponent {
     isSummary: PropTypes.bool
   }
 
-  _getDurationObj = durationInMilliseconds => {
-    const dur = moment.duration(durationInMilliseconds, 'ms');
-    return {
-      duration: dur,
-      hrs: dur.get('h'),
-      min: dur.get('m'),
-      sec: dur.get('s'),
-      ms: dur.get('ms')
-    };
+  _getDurationObj = durationInMs => {
+    const DAY = 24 * 60 * 60 * 1000;
+    const HOUR = 60 * 60 * 1000;
+    const MINUTE = 60 * 1000;
+    const SECOND = 1000;
+
+    const days = Math.floor(durationInMs / DAY);
+    const daysms = durationInMs % DAY;
+    const hrs = Math.floor(daysms / HOUR);
+    const hrsms = durationInMs % HOUR;
+    const min = Math.floor(hrsms / MINUTE);
+    const minms = durationInMs % MINUTE;
+    const sec = Math.floor(minms / SECOND);
+    const ms = durationInMs % SECOND;
+
+    return { days, hrs, min, sec, ms };
   }
 
   formatSummaryDuration = context => {
-    const { hrs, min, sec, ms } = context;
-    if (hrs < 1) {
-      if (min < 1) {
-        if (sec < 1) {
-          return ms;
+    const { days, hrs, min, sec, ms } = context;
+    if (days < 1) {
+      if (hrs < 1) {
+        if (min < 1) {
+          if (sec < 1) {
+            return ms;
+          }
+          return `${sec}.${ms}`;
         }
-        return `${sec}.${ms}`;
+        return `${min}:${sec < 10 ? `0${sec}` : sec}`;
       }
-      return `${min}:${sec < 10 ? `0${sec}` : sec}`;
+      return `${hrs}:${min < 10 ? `0${min}` : min}`;
     }
-    return `${hrs}:${min < 10 ? `0${min}` : min}`;
+    return `${days}d ${hrs}:${min < 10 ? `0${min}` : min}`;
   }
 
   formatDuration = context => {
-    const { hrs, min, sec, ms } = context;
-    if (hrs < 1) {
-      if (min < 1) {
-        if (sec < 1) {
-          return `${ms}ms`;
+    const { days, hrs, min, sec, ms } = context;
+    if (days < 1) {
+      if (hrs < 1) {
+        if (min < 1) {
+          if (sec < 1) {
+            return `${ms}ms`;
+          }
+          return `${sec}.${ms}s`;
         }
-        return `${sec}.${ms}s`;
+        return `${min}:${sec < 10 ? `0${sec}` : sec}.${ms}m`;
       }
-      return `${min}:${sec < 10 ? `0${sec}` : sec}.${ms}m`;
+      return `${hrs}:${min < 10 ? `0${min}` : min}:${sec < 10 ? `0${sec}` : sec}.${ms}h`;
     }
-    return `${hrs}:${min < 10 ? `0${min}` : min}:${sec < 10 ? `0${sec}` : sec}.${ms}h`;
+    return `${days}d ${hrs}:${min < 10 ? `0${min}` : min}:${sec < 10 ? `0${sec}` : sec}.${ms}h`;
   }
 
   getSummaryDurationUnits = context => {
@@ -55,13 +67,13 @@ class Duration extends PureComponent {
     if (hrs < 1) {
       if (min < 1) {
         if (sec < 1) {
-          return 'MS';
+          return 'ms';
         }
-        return 'S';
+        return 's';
       }
-      return 'M';
+      return 'm';
     }
-    return 'H';
+    return 'h';
   }
 
   render() {

--- a/src/components/nav-menu/nav-menu.jsx
+++ b/src/components/nav-menu/nav-menu.jsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { inject, observer } from 'mobx-react';
-import moment from 'moment';
+import { format } from 'date-fns';
 import find from 'lodash/find';
 import { Icon, ToggleSwitch, DropdownSelector } from 'components';
 import { NavMenuItem } from 'components/nav-menu';
@@ -71,7 +71,7 @@ class NavMenu extends Component {
           <div className={ cx('section') }>
             <h3 className={ cx('title') }>{ reportTitle }</h3>
             <h6 className={ cx('date') }>
-              { moment(stats.end).format('dddd, MMMM D YYYY, hh:mma') }
+              { format(stats.end, 'dddd, MMMM D, YYYY h:mma') }
             </h6>
           </div>
           <div className={ cx('section') }>

--- a/src/components/quick-summary/quick-summary.css
+++ b/src/components/quick-summary/quick-summary.css
@@ -55,13 +55,6 @@
       background-color: var(--grey100);
     }
   }
-
-  &.duration {
-    & .duration-units {
-      font-size: 14px;
-      text-transform: lowercase;
-    }
-  }
 }
 
 /* Icons / Colors */

--- a/test/spec/components/duration.test.jsx
+++ b/test/spec/components/duration.test.jsx
@@ -32,20 +32,28 @@ describe('<Duration />', () => {
     const wrapper = shallow(<Duration timer={ 7625134 } />);
     expect(wrapper.text()).to.equal('2:07:05.134h');
   });
+  it('days', () => {
+    const wrapper = shallow(<Duration timer={ 123456789 } />);
+    expect(wrapper.text()).to.equal('1d 10:17:36.789h');
+  });
   it('summary duration milliseconds', () => {
     const wrapper = shallow(<Duration timer={ 234 } isSummary />);
-    expect(wrapper.text()).to.equal('234MS');
+    expect(wrapper.text()).to.equal('234ms');
   });
   it('summary duration seconds', () => {
     const wrapper = shallow(<Duration timer={ 1234 } isSummary />);
-    expect(wrapper.text()).to.equal('1.234S');
+    expect(wrapper.text()).to.equal('1.234s');
   });
   it('summary duration minutes', () => {
     const wrapper = shallow(<Duration timer={ 91234 } isSummary />);
-    expect(wrapper.text()).to.equal('1:31M');
+    expect(wrapper.text()).to.equal('1:31m');
   });
   it('summary duration hours', () => {
     const wrapper = shallow(<Duration timer={ 7625134 } isSummary />);
-    expect(wrapper.text()).to.equal('2:07H');
+    expect(wrapper.text()).to.equal('2:07h');
+  });
+  it('summary duration days', () => {
+    const wrapper = shallow(<Duration timer={ 123456789 } isSummary />);
+    expect(wrapper.text()).to.equal('1d 10:17h');
   });
 });


### PR DESCRIPTION
moment.js is great but bloats the bundle size. Since this project doesn't really need all of moment this PR replaces it.
- Replace moment.duration with vanilla js function
- Replace moment.format with `format` from date-fns