### PR TITLE
feat: Add video tag support for context

### DIFF
--- a/src/components/test/context.jsx
+++ b/src/components/test/context.jsx
@@ -7,6 +7,7 @@ import styles from './test.css';
 
 const cx = classNames.bind(styles);
 
+const videoRegEx = /(?:mp4|webm)$/i;
 const imgRegEx = /(?:png|jpe?g|gif)$/i;
 const protocolRegEx = /^(?:(?:https?|ftp):\/\/)/i;
 const urlRegEx = /^(?:(?:https?|ftp):\/\/)?(?:\S+(?::\S*)?@)?(?:(?!(?:10|127)(?:\.\d{1,3}){3})(?!(?:169\.254|192\.168)(?:\.\d{1,3}){2})(?!172\.(?:1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2})(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-z\u00a1-\uffff0-9]-*)*[a-z\u00a1-\uffff0-9]+)(?:\.(?:[a-z\u00a1-\uffff0-9]-*)*[a-z\u00a1-\uffff0-9]+)*(?:\.(?:[a-z\u00a1-\uffff]{2,}))\.?)(?::\d{2,5})?(?:[/?#]\S*)?$/ // eslint-disable-line
@@ -23,6 +24,19 @@ class TestContext extends Component {
       PropTypes.array
     ])
   };
+
+  renderVideo = (ctx, title) => {
+    const isUrl = urlRegEx.test(ctx);
+    const hasProtocol = protocolRegEx.test(ctx);
+    const linkUrl = (isUrl && !hasProtocol) ? `http://${ctx}` : ctx;
+
+    return (
+      <video controls src={ linkUrl } className={ cx('video') }>
+        <track kind='captions' />
+        {title}
+      </video>
+    );
+  }
 
   renderImage = (ctx, title) => {
     const isUrl = urlRegEx.test(ctx);
@@ -56,6 +70,11 @@ class TestContext extends Component {
   }
 
   renderContextContent = (content, title, highlight = false) => {
+    // Videos
+    if (videoRegEx.test(content)) {
+      return this.renderVideo(content, title);
+    }
+
     // Images
     if (imgRegEx.test(content)) {
       return this.renderImage(content, title);

--- a/src/components/test/context.jsx
+++ b/src/components/test/context.jsx
@@ -33,7 +33,14 @@ class TestContext extends Component {
     return (
       <video controls src={ linkUrl } className={ cx('video') }>
         <track kind='captions' />
-        {title}
+        { title }
+        <a
+          href={linkUrl}
+          className={ cx('video-link') }
+          rel='noopener noreferrer'
+          target='_blank' >
+          { linkUrl }
+        </a>
       </video>
     );
   }

--- a/src/components/test/context.jsx
+++ b/src/components/test/context.jsx
@@ -35,7 +35,7 @@ class TestContext extends Component {
         <track kind='captions' />
         { title }
         <a
-          href={linkUrl}
+          href={ linkUrl }
           className={ cx('video-link') }
           rel='noopener noreferrer'
           target='_blank' >

--- a/src/components/test/test.css
+++ b/src/components/test/test.css
@@ -264,3 +264,9 @@
   max-width: 100%;
   height: auto;
 }
+
+.video {
+  display: block;
+  max-width: 100%;
+  height: auto;
+}

--- a/src/components/test/test.css
+++ b/src/components/test/test.css
@@ -253,19 +253,13 @@
   }
 }
 
-.image-link {
+.image-link, .video-link {
   display: inline-block;
   font-size: 11px;
   padding: 0 1em 1em 1em;
 }
 
-.image {
-  display: block;
-  max-width: 100%;
-  height: auto;
-}
-
-.video {
+.image, .video {
   display: block;
   max-width: 100%;
   height: auto;

--- a/test/spec/components/test/context.test.jsx
+++ b/test/spec/components/test/context.test.jsx
@@ -18,6 +18,8 @@ describe('<TestContext />', () => {
       ctxItems: wrapper.find('.test-context-item'),
       img: wrapper.find('.test-image'),
       imgLink: wrapper.find('.test-image-link'),
+      video: wrapper.find('.test-video'),
+      videoLink: wrapper.find('.test-video-link'),
       link: wrapper.find('.test-text-link'),
       snippet: wrapper.find(CodeSnippet)
     };
@@ -133,6 +135,45 @@ describe('<TestContext />', () => {
       expect(wrapper).to.have.className('test');
       expect(snippet).to.have.lengthOf(0);
       expect(img).to.have.lengthOf(1);
+    });
+
+    it('renders local video', () => {
+      const context = '/testvideo.mp4';
+      const { wrapper, snippet, video } = getInstance({
+        context: JSON.stringify(context),
+        className: 'test'
+      });
+      expect(wrapper).to.have.className('test');
+      expect(snippet).to.have.lengthOf(0);
+      expect(wrapper).to.have.descendants('video');
+      expect(video).to.have.attr('src', '/testvideo.mp4');
+    });
+
+    it('renders video url with protocol', () => {
+      const context = 'http://test.url.com/testvideo.mp4';
+      const { wrapper, snippet, videoLink } = getInstance({
+        context: JSON.stringify(context),
+        className: 'test'
+      });
+      expect(wrapper).to.have.className('test');
+      expect(snippet).to.have.lengthOf(0);
+      expect(wrapper).to.have.descendants('video');
+      expect(wrapper).to.have.descendants('a.test-video-link');
+      expect(videoLink).to.have.attr('href', 'http://test.url.com/testvideo.mp4');
+      videoLink.simulate('click', { stopPropagation: noop });
+    });
+
+    it('renders image url without protocol', () => {
+      const context = 'test.url.com/testvideo.mp4';
+      const { wrapper, snippet, videoLink } = getInstance({
+        context: JSON.stringify(context),
+        className: 'test'
+      });
+      expect(wrapper).to.have.className('test');
+      expect(snippet).to.have.lengthOf(0);
+      expect(wrapper).to.have.descendants('video');
+      expect(wrapper).to.have.descendants('a.test-video-link');
+      expect(videoLink).to.have.attr('href', 'http://test.url.com/testvideo.mp4');
     });
   });
 

--- a/test/spec/components/test/context.test.jsx
+++ b/test/spec/components/test/context.test.jsx
@@ -145,7 +145,7 @@ describe('<TestContext />', () => {
       });
       expect(wrapper).to.have.className('test');
       expect(snippet).to.have.lengthOf(0);
-      expect(wrapper).to.have.descendants('video');
+      expect(wrapper).to.have.exactly(1).descendants('video');
       expect(video).to.have.attr('src', '/testvideo.mp4');
     });
 
@@ -157,10 +157,9 @@ describe('<TestContext />', () => {
       });
       expect(wrapper).to.have.className('test');
       expect(snippet).to.have.lengthOf(0);
-      expect(wrapper).to.have.descendants('video');
-      expect(wrapper).to.have.descendants('a.test-video-link');
+      expect(wrapper).to.have.exactly(1).descendants('video');
+      expect(wrapper).to.have.exactly(1).descendants('a.test-video-link');
       expect(videoLink).to.have.attr('href', 'http://test.url.com/testvideo.mp4');
-      videoLink.simulate('click', { stopPropagation: noop });
     });
 
     it('renders image url without protocol', () => {
@@ -171,8 +170,8 @@ describe('<TestContext />', () => {
       });
       expect(wrapper).to.have.className('test');
       expect(snippet).to.have.lengthOf(0);
-      expect(wrapper).to.have.descendants('video');
-      expect(wrapper).to.have.descendants('a.test-video-link');
+      expect(wrapper).to.have.exactly(1).descendants('video');
+      expect(wrapper).to.have.exactly(1).descendants('a.test-video-link');
       expect(videoLink).to.have.attr('href', 'http://test.url.com/testvideo.mp4');
     });
   });


### PR DESCRIPTION
This is a very simple implementation of adding video support. It recognizes a video link in the context and makes a `video` tag instead of just a URL. It follows the same implementation of the `img` tag. Not all video extensions are supported - just the ones I tested. More could easily be added.

It looks like this:
![screen shot 2018-01-20 at 9 57 33 am](https://user-images.githubusercontent.com/338257/35185899-7e367f3a-fdc8-11e7-9052-cf5e1f30e268.png)
