### PR TITLE
preserve toggle state in localStorage

### DIFF
--- a/src/js/reportStore.js
+++ b/src/js/reportStore.js
@@ -6,6 +6,16 @@ const transduce = (items, mapper, reducer, initial) =>
     initial
   );
 
+const initPropState = (prop, config) => {
+  const exists = p => typeof p !== 'undefined' && p !== null;
+  const ls = localStorage.getItem(prop);
+  const cs = config[prop];
+
+  // eslint-disable-next-line no-nested-ternary
+  const state = exists(ls) ? ls === 'true' : exists(cs) ? cs : true;
+  return state;
+};
+
 class ReportStore {
   constructor(data = {}, config = {}) {
     Object.assign(this, config, {
@@ -22,11 +32,11 @@ class ReportStore {
     extendObservable(this, {
       filteredSuites: observable.shallow([]),
       isLoading: true,
-      showFailed: config.showFailed !== undefined ? config.showFailed : true,
+      showFailed: initPropState('showFailed', config),
       showHooks: this._getShowHooks(config),
-      showPassed: config.showPassed !== undefined ? config.showPassed : true,
-      showPending: config.showPending !== undefined ? config.showPending : true,
-      showSkipped: config.showSkipped !== undefined ? config.showSkipped : false,
+      showPassed: initPropState('showPassed', config),
+      showPending: initPropState('showPending', config),
+      showSkipped: initPropState('showSkipped', config),
       sideNavOpen: false
     });
   }
@@ -42,6 +52,9 @@ class ReportStore {
   @action.bound toggleFilter(prop) {
     this.toggleIsLoading(true);
     this[prop] = !this[prop];
+    if (localStorage) {
+      localStorage.setItem(prop, this[prop]);
+    }
   }
 
   @action.bound setShowHooks(prop) {
@@ -59,16 +72,16 @@ class ReportStore {
 
   _mapHook = hook => (
     ((this.showHooks === 'always')
-    || (this.showHooks === 'failed' && hook.fail)
-    || (this.showHooks === 'context' && hook.context))
+      || (this.showHooks === 'failed' && hook.fail)
+      || (this.showHooks === 'context' && hook.context))
     && hook
   )
 
   _mapTest = test => (
     ((this.showPassed && test.pass)
-    || (this.showFailed && test.fail)
-    || (this.showPending && test.pending)
-    || (this.showSkipped && test.skipped))
+      || (this.showFailed && test.fail)
+      || (this.showPending && test.pending)
+      || (this.showSkipped && test.skipped))
     && test
   )
 


### PR DESCRIPTION
Hi Adam,

I added a few lines of code to preserve the toggle state between page loads.  I need this feature because I run tests against multiple servers, and find myself have to re-toggle.

Another idea I have is to make the upper right icons clickable, so that they would set to true only that state (showFailed, for example) and not the others.

Thanks in advance for looking this over.

-- Jeff