### PR TITLE
Update TestState enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # mochawesome-report-generator changelog
 
 ## Unreleased
+### Changed
+- Added `pending` and `skipped` to `TestState` enum. [#111](https://github.com/adamgruber/mochawesome-report-generator/issues/111)
 
 ## [3.1.3] / 2018-07-18
 ### Fixed

--- a/bin/src/types.js
+++ b/bin/src/types.js
@@ -2,7 +2,7 @@ const t = require('tcomb');
 const { isUUID, isISO8601 } = require('validator');
 
 const PercentClass = t.enums.of([ 'success', 'warning', 'danger' ], 'PercentClass');
-const TestState = t.enums.of([ 'passed', 'failed' ], 'TestState');
+const TestState = t.enums.of([ 'passed', 'failed', 'pending', 'skipped' ], 'TestState');
 const TestSpeed = t.enums.of([ 'slow', 'medium', 'fast' ], 'TestSpeed');
 const DateString = t.refinement(t.String, isISO8601, 'DateString');
 const Duration = t.maybe(t.Integer);


### PR DESCRIPTION
Add `pending` and `skipped` to `TestState` enum for better support with Cypress. Fixes #111