### PR TITLE
Allow filtering tests by clicking summary icons

### DIFF
--- a/src/client/components/material-icon/index.js
+++ b/src/client/components/material-icon/index.js
@@ -6,7 +6,7 @@ import iconmap from './icon-map.json';
 
 class Icon extends PureComponent {
   render() {
-    const { className, name, size, foreground } = this.props;
+    const { className, name, size, foreground, onClick } = this.props;
     const iconCode = iconmap[name];
     const cxName = classNames(
       'material-icons',
@@ -19,6 +19,9 @@ class Icon extends PureComponent {
         <i
           className={cxName}
           dangerouslySetInnerHTML={{ __html: `&#x${iconCode};` }}
+          {...(onClick ? {onClick} : {})}
+          role="button"
+          tabIndex="0"
         />
       )
     );
@@ -30,6 +33,7 @@ Icon.propTypes = {
   name: PropTypes.string,
   size: PropTypes.oneOf([18, 24, 36, 48]),
   foreground: PropTypes.oneOf(['light', 'dark']),
+  onClick: PropTypes.func,
 };
 
 Icon.displayName = 'MaterialIcon';

--- a/src/client/components/material-icon/index.js
+++ b/src/client/components/material-icon/index.js
@@ -19,9 +19,11 @@ class Icon extends PureComponent {
         <i
           className={cxName}
           dangerouslySetInnerHTML={{ __html: `&#x${iconCode};` }}
-          {...(onClick ? {onClick} : {})}
-          role="button"
-          tabIndex="0"
+          {...(onClick ? {
+            onClick,
+            role: 'button',
+            tabIndex: '0',
+          } : {})}
         />
       )
     );

--- a/src/client/components/quick-summary/index.js
+++ b/src/client/components/quick-summary/index.js
@@ -1,70 +1,79 @@
-import React from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import { inject } from 'mobx-react';
 import { Duration, Icon } from 'components';
 import classNames from 'classnames/bind';
 import styles from './quick-summary.css';
 
 const cx = classNames.bind(styles);
 
-const QuickSummary = ({ stats }) => {
-  const {
-    duration,
-    suites,
-    testsRegistered,
-    passes,
-    failures,
-    pending,
-    skipped,
-  } = stats;
-  return (
-    <div className={cx('cnt')}>
-      <ul className={cx('list')}>
-        <li className={cx('item', 'duration')} title="Duration">
-          <Icon name="timer" className={cx('icon')} />
-          <Duration
-            unitsClassName={cx('duration-units')}
-            timer={duration}
-            isSummary
-          />
-        </li>
-        <li className={cx('item', 'suites')} title="Suites">
-          <Icon name="library_books" className={cx('icon')} />
-          {suites}
-        </li>
-        <li className={cx('item', 'tests')} title="Tests">
-          <Icon name="assignment" className={cx('icon')} />
-          {testsRegistered}
-        </li>
-      </ul>
-      <ul className={cx('list')}>
-        <li className={cx('item', 'passes')} title="Passed">
-          <Icon name="check" className={cx('icon', 'circle-icon')} />
-          {passes}
-        </li>
-        <li className={cx('item', 'failures')} title="Failed">
-          <Icon name="close" className={cx('icon', 'circle-icon')} />
-          {failures}
-        </li>
-        {!!pending && (
-          <li className={cx('item', 'pending')} title="Pending">
-            <Icon name="pause" className={cx('icon', 'circle-icon')} />
-            {pending}
-          </li>
-        )}
-        {!!skipped && (
-          <li className={cx('item', 'skipped')} title="Skipped">
-            <Icon name="stop" className={cx('icon', 'circle-icon')} />
-            {skipped}
-          </li>
-        )}
-      </ul>
-    </div>
-  );
-};
+@inject('reportStore')
+class QuickSummary extends Component {
+  static propTypes = {
+    stats: PropTypes.object,
+    reportStore: PropTypes.shape({
+      filterOnly: PropTypes.func,
+    }),
+  };
 
-QuickSummary.propTypes = {
-  stats: PropTypes.object,
-};
+  render() {
+    const {
+      duration,
+      suites,
+      testsRegistered,
+      passes,
+      failures,
+      pending,
+      skipped,
+    } = this.props.stats;
+    const { filterOnly } = this.props.reportStore;
+
+    return (
+      <div className={cx('cnt')}>
+        <ul className={cx('list')}>
+          <li className={cx('item', 'duration')} title="Duration">
+            <Icon name="timer" className={cx('icon')} />
+            <Duration
+              unitsClassName={cx('duration-units')}
+              timer={duration}
+              isSummary
+            />
+          </li>
+          <li className={cx('item', 'suites')} title="Suites">
+            <Icon name="library_books" className={cx('icon')} />
+            {suites}
+          </li>
+          <li className={cx('item', 'tests')} title="Tests">
+            <Icon name="assignment" className={cx('icon')} />
+            {testsRegistered}
+          </li>
+        </ul>
+        <ul className={cx('list')}>
+          <li className={cx('item', 'passes')} title="Passed">
+            <Icon name="check" className={cx('icon', 'circle-icon')} onClick={() => filterOnly('showPassed')} />
+            {passes}
+          </li>
+          <li className={cx('item', 'failures')} title="Failed">
+            <Icon name="close" className={cx('icon', 'circle-icon')} onClick={() => filterOnly('showFailed')} />
+            {failures}
+          </li>
+          {!!pending && (
+            <li className={cx('item', 'pending')} title="Pending">
+              <Icon name="pause" className={cx('icon', 'circle-icon')} onClick={() => filterOnly('showPending')} />
+              {pending}
+            </li>
+          )}
+          {!!skipped && (
+            <li className={cx('item', 'skipped')} title="Skipped">
+              <Icon name="stop" className={cx('icon', 'circle-icon')} onClick={() => filterOnly('showSkipped')} />
+              {skipped}
+            </li>
+          )}
+        </ul>
+      </div>
+    );
+  }
+}
 
 QuickSummary.displayName = 'QuickSummary';
 

--- a/src/client/js/reportStore.js
+++ b/src/client/js/reportStore.js
@@ -52,6 +52,16 @@ class ReportStore {
   }
 
   @action.bound
+  filterOnly(prop) {
+    this.toggleIsLoading(true);
+    this.showPassed = false;
+    this.showFailed = false;
+    this.showPending = false;
+    this.showSkipped = false;
+    this[prop] = true;
+  }
+
+  @action.bound
   setShowHooks(prop) {
     if (this._isValidShowHookOption(prop)) {
       this.toggleIsLoading(true);

--- a/src/client/styles/app.global.css
+++ b/src/client/styles/app.global.css
@@ -50,6 +50,8 @@
   word-wrap: normal;
   white-space: nowrap;
   direction: ltr;
+  cursor: default;
+  user-select: none;
 
   /* Support for all WebKit browsers. */
   -webkit-font-smoothing: antialiased;

--- a/src/client/styles/app.global.css
+++ b/src/client/styles/app.global.css
@@ -50,7 +50,7 @@
   word-wrap: normal;
   white-space: nowrap;
   direction: ltr;
-  cursor: default;
+  cursor: pointer;
   user-select: none;
 
   /* Support for all WebKit browsers. */

--- a/test/spec/components/quick-summary.test.js
+++ b/test/spec/components/quick-summary.test.js
@@ -29,6 +29,9 @@ describe('<QuickSummary />', () => {
         pending: 5,
         skipped: 8,
       },
+      reportStore: {
+        filterOnly: () => null,
+      }
     };
   });
 


### PR DESCRIPTION
This pull request allows filtering tests (passing, failed, pending, skipped) by pressing the quick summary icons on the navbar.

Changes:

- added an `onClick` prop to Icon
- added store action to only filter one test category (`filterOnly()`)
- make icons un-selectable to act more like buttons rather than text