### PR TITLE
Update how durations are displayed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # mochawesome-report-generator changelog
 
 ## [Unreleased]
+### Changed
+- Replace custom duration formatting with `pretty-ms` [mochawesome #322](https://github.com/adamgruber/mochawesome/issues/322)
 
 ## [5.1.0] - 2020-04-13
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -11146,6 +11146,12 @@
         "json-parse-better-errors": "^1.0.1"
       }
     },
+    "parse-ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-2.1.0.tgz",
+      "integrity": "sha512-kHt7kzLoS9VBZfUsiKjv43mr91ea+U05EyKkEtqp7vNbHxmaVuEqN7XxeEVnGrMtYOAxGrDElSi96K7EgO1zCA==",
+      "dev": true
+    },
     "parse-passwd": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
@@ -12501,6 +12507,15 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.16.4.tgz",
       "integrity": "sha1-c+N+c+AYrS25x2dC4mR+IXkMlxc=",
       "dev": true
+    },
+    "pretty-ms": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-7.0.0.tgz",
+      "integrity": "sha512-J3aPWiC5e9ZeZFuSeBraGxSkGMOvulSWsxDByOcbD1Pr75YL3LSNIKIb52WXbCLE1sS5s4inBBbryjF4Y05Ceg==",
+      "dev": true,
+      "requires": {
+        "parse-ms": "^2.1.0"
+      }
     },
     "private": {
       "version": "0.1.8",

--- a/package.json
+++ b/package.json
@@ -145,6 +145,7 @@
     "postcss-reporter": "^6.0.1",
     "postcss-url": "^8.0.0",
     "prettier": "^1.16.4",
+    "pretty-ms": "^7.0.0",
     "proxyquire": "^2.1.0",
     "raf": "^3.4.0",
     "react": "^16.13.1",

--- a/src/client/components/duration.js
+++ b/src/client/components/duration.js
@@ -1,103 +1,25 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import prettyMs from 'pretty-ms';
 
 class Duration extends PureComponent {
   static propTypes = {
     className: PropTypes.string,
-    unitsClassName: PropTypes.string,
     timer: PropTypes.number,
-    isSummary: PropTypes.bool,
   };
 
-  _getDurationObj = durationInMs => {
-    const DAY = 24 * 60 * 60 * 1000;
-    const HOUR = 60 * 60 * 1000;
-    const MINUTE = 60 * 1000;
-    const SECOND = 1000;
-
-    const days = Math.floor(durationInMs / DAY);
-    const daysms = durationInMs % DAY;
-    const hrs = Math.floor(daysms / HOUR);
-    const hrsms = durationInMs % HOUR;
-    const min = Math.floor(hrsms / MINUTE);
-    const minms = durationInMs % MINUTE;
-    const sec = Math.floor(minms / SECOND);
-    const ms = durationInMs % SECOND;
-
-    return { days, hrs, min, sec, ms };
-  };
-
-  formatSummaryDuration = context => {
-    const { days, hrs, min, sec, ms } = context;
-    if (days < 1) {
-      if (hrs < 1) {
-        if (min < 1) {
-          if (sec < 1) {
-            return ms;
-          }
-          return `${sec}.${ms}`;
-        }
-        return `${min}:${sec < 10 ? `0${sec}` : sec}`;
-      }
-      return `${hrs}:${min < 10 ? `0${min}` : min}`;
-    }
-    return `${days}d ${hrs}:${min < 10 ? `0${min}` : min}`;
-  };
-
-  formatDuration = context => {
-    const { days, hrs, min, sec, ms } = context;
-    if (days < 1) {
-      if (hrs < 1) {
-        if (min < 1) {
-          if (sec < 1) {
-            return `${ms}ms`;
-          }
-          return `${sec}.${ms}s`;
-        }
-        return `${min}:${sec < 10 ? `0${sec}` : sec}.${ms}m`;
-      }
-      return `${hrs}:${min < 10 ? `0${min}` : min}:${
-        sec < 10 ? `0${sec}` : sec
-      }.${ms}h`;
-    }
-    return `${days}d ${hrs}:${min < 10 ? `0${min}` : min}:${
-      sec < 10 ? `0${sec}` : sec
-    }.${ms}h`;
-  };
-
-  getSummaryDurationUnits = context => {
-    const { hrs, min, sec } = context;
-    if (hrs < 1) {
-      if (min < 1) {
-        if (sec < 1) {
-          return 'ms';
-        }
-        return 's';
-      }
-      return 'm';
-    }
-    return 'h';
-  };
+  formatDuration = ms =>
+    prettyMs(ms, {
+      unitCount: 3,
+    });
 
   render() {
-    const { className, unitsClassName, timer, isSummary } = this.props;
-    const duration = this._getDurationObj(timer);
-    const summaryDuration = this.formatSummaryDuration(duration);
-    const units = this.getSummaryDurationUnits(duration);
-
-    if (isSummary) {
-      return (
-        <span>
-          <span className={classNames(className)}>{summaryDuration}</span>
-          <span className={classNames(unitsClassName)}>{units}</span>
-        </span>
-      );
-    }
+    const { className, timer } = this.props;
 
     return (
       <span className={classNames(className)}>
-        {this.formatDuration(duration)}
+        {this.formatDuration(timer)}
       </span>
     );
   }

--- a/src/client/components/quick-summary/index.js
+++ b/src/client/components/quick-summary/index.js
@@ -26,11 +26,7 @@ const QuickSummary = ({ onQuickFilterClick, singleFilter, stats }) => {
       <ul className={cx('list')}>
         <li className={cx('item', 'duration')} title="Duration">
           <Icon name="timer" className={cx('icon')} />
-          <Duration
-            unitsClassName={cx('duration-units')}
-            timer={duration}
-            isSummary
-          />
+          <Duration timer={duration} />
         </li>
         <li className={cx('item', 'suites')} title="Suites">
           <Icon name="library_books" className={cx('icon')} />
@@ -43,20 +39,26 @@ const QuickSummary = ({ onQuickFilterClick, singleFilter, stats }) => {
       </ul>
       <ul className={cx('list', filterClasses)}>
         <li className={cx('item', 'passes')} title="Passed">
-          <button type="button" onClick={() => onQuickFilterClick('showPassed')}>
+          <button
+            type="button"
+            onClick={() => onQuickFilterClick('showPassed')}>
             <Icon name="check" className={cx('icon', 'circle-icon')} />
             {passes}
           </button>
         </li>
         <li className={cx('item', 'failures')} title="Failed">
-          <button type="button" onClick={() => onQuickFilterClick('showFailed')}>
+          <button
+            type="button"
+            onClick={() => onQuickFilterClick('showFailed')}>
             <Icon name="close" className={cx('icon', 'circle-icon')} />
             {failures}
           </button>
         </li>
         {!!pending && (
           <li className={cx('item', 'pending')} title="Pending">
-            <button type="button" onClick={() => onQuickFilterClick('showPending')}>
+            <button
+              type="button"
+              onClick={() => onQuickFilterClick('showPending')}>
               <Icon name="pause" className={cx('icon', 'circle-icon')} />
               {pending}
             </button>
@@ -64,7 +66,9 @@ const QuickSummary = ({ onQuickFilterClick, singleFilter, stats }) => {
         )}
         {!!skipped && (
           <li className={cx('item', 'skipped')} title="Skipped">
-            <button type="button" onClick={() => onQuickFilterClick('showSkipped')}>
+            <button
+              type="button"
+              onClick={() => onQuickFilterClick('showSkipped')}>
               <Icon name="stop" className={cx('icon', 'circle-icon')} />
               {skipped}
             </button>

--- a/src/client/components/summary/index.js
+++ b/src/client/components/summary/index.js
@@ -22,7 +22,7 @@ const Summary = props => {
         <div className="row">
           <div className={cx('col', 'duration')}>
             <h1 className={cx('count')}>
-              <Duration timer={duration} isSummary />
+              <Duration timer={duration} />
             </h1>
             <h4 className={cx('label')}>{}</h4>
           </div>

--- a/test/spec/components/duration.test.js
+++ b/test/spec/components/duration.test.js
@@ -14,27 +14,27 @@ describe('<Duration />', () => {
   });
   it('seconds', () => {
     const wrapper = shallow(<Duration timer={5000} />);
-    expect(wrapper.text()).to.equal('5.0s');
+    expect(wrapper.text()).to.equal('5s');
   });
   it('minutes', () => {
     const wrapper = shallow(<Duration timer={91234} />);
-    expect(wrapper.text()).to.equal('1:31.234m');
+    expect(wrapper.text()).to.equal('1m 31.2s');
   });
   it('minutes with leading zeroes', () => {
     const wrapper = shallow(<Duration timer={61234} />);
-    expect(wrapper.text()).to.equal('1:01.234m');
+    expect(wrapper.text()).to.equal('1m 1.2s');
   });
   it('hours', () => {
     const wrapper = shallow(<Duration timer={8531234} />);
-    expect(wrapper.text()).to.equal('2:22:11.234h');
+    expect(wrapper.text()).to.equal('2h 22m 11.2s');
   });
   it('hours with leading zeroes', () => {
     const wrapper = shallow(<Duration timer={7625134} />);
-    expect(wrapper.text()).to.equal('2:07:05.134h');
+    expect(wrapper.text()).to.equal('2h 7m 5.1s');
   });
   it('days', () => {
     const wrapper = shallow(<Duration timer={123456789} />);
-    expect(wrapper.text()).to.equal('1d 10:17:36.789h');
+    expect(wrapper.text()).to.equal('1d 10h 17m');
   });
   it('summary duration milliseconds', () => {
     const wrapper = shallow(<Duration timer={234} isSummary />);
@@ -42,18 +42,18 @@ describe('<Duration />', () => {
   });
   it('summary duration seconds', () => {
     const wrapper = shallow(<Duration timer={1234} isSummary />);
-    expect(wrapper.text()).to.equal('1.234s');
+    expect(wrapper.text()).to.equal('1.2s');
   });
   it('summary duration minutes', () => {
     const wrapper = shallow(<Duration timer={91234} isSummary />);
-    expect(wrapper.text()).to.equal('1:31m');
+    expect(wrapper.text()).to.equal('1m 31.2s');
   });
   it('summary duration hours', () => {
     const wrapper = shallow(<Duration timer={7625134} isSummary />);
-    expect(wrapper.text()).to.equal('2:07h');
+    expect(wrapper.text()).to.equal('2h 7m 5.1s');
   });
   it('summary duration days', () => {
     const wrapper = shallow(<Duration timer={123456789} isSummary />);
-    expect(wrapper.text()).to.equal('1d 10:17h');
+    expect(wrapper.text()).to.equal('1d 10h 17m');
   });
 });

--- a/test/spec/components/navbar.test.js
+++ b/test/spec/components/navbar.test.js
@@ -48,7 +48,7 @@ describe('<Navbar />', () => {
     beforeEach(() => {
       props = {
         reportTitle: 'test',
-        stats: { passPercent: 0, pendingPercent: 100 },
+        stats: { duration: 30, passPercent: 0, pendingPercent: 100 },
       };
     });
 
@@ -63,7 +63,7 @@ describe('<Navbar />', () => {
     beforeEach(() => {
       props = {
         reportTitle: 'test',
-        stats: { passPercent: null, pendingPercent: null },
+        stats: { duration: 30, passPercent: null, pendingPercent: null },
       };
     });
 


### PR DESCRIPTION
Replaces custom duration format logic with `pretty-ms` for more human-readable durations.

Fixes https://github.com/adamgruber/mochawesome/issues/322