### PR TITLE
Upgrade `opener` to 1.5.2 to resolve security issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10958,9 +10958,9 @@
       }
     },
     "opener": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.1.tgz",
-      "integrity": "sha1-bS8Od/GgrwAyrKcWwsH7uOfoq+0="
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
+      "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A=="
     },
     "opn": {
       "version": "5.5.0",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "fs-extra": "^7.0.0",
     "fsu": "^1.0.2",
     "lodash.isfunction": "^3.0.8",
-    "opener": "^1.4.2",
+    "opener": "^1.5.2",
     "prop-types": "^15.7.2",
     "tcomb": "^3.2.17",
     "tcomb-validation": "^3.3.0",


### PR DESCRIPTION
There was a [security issue](https://securitylab.github.com/advisories/GHSL-2020-145-domenic-opener) found in `opener`. It's resolved in 1.5.2.