### PR TITLE
bump validator from 10.11.0 to 13.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15718,9 +15718,9 @@
       }
     },
     "validator": {
-      "version": "10.11.0",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-10.11.0.tgz",
-      "integrity": "sha1-ADEI6m6amHTTHMyeUAaFbM12sig="
+      "version": "13.6.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.6.0.tgz",
+      "integrity": "sha512-gVgKbdbHgtxpRyR8K0O6oFZPhhB5tT1jeEHZR0Znr9Svg03U0+r9DXWMrnRAB+HtCStDQKlaIZm42tVsVjqtjg=="
     },
     "vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "prop-types": "^15.7.2",
     "tcomb": "^3.2.17",
     "tcomb-validation": "^3.3.0",
-    "validator": "^10.11.0",
+    "validator": "^13.6.0",
     "yargs": "^13.2.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Bumping this dependency (and making any required changes to make tests pass), will reduce the number of vulnerabilities found in [this Snyk report](https://snyk.io/test/npm/mochawesome-report-generator/5.2.0).