### PR TITLE
Fix an error related to generating reports in empty tests

### DIFF
--- a/src/lib/main.js
+++ b/src/lib/main.js
@@ -119,7 +119,7 @@ function getFilename({ reportDir, reportFilename, timestamp }, reportData) {
   }
 
   const specFilename = path
-    .basename(reportData.results[0].file || '')
+    .basename(reportData.results[0]?.file || '')
     .replace(/\..+/, '');
 
   const status = reportData.stats.failures > 0 ? STATUSES.Fail : STATUSES.Pass;


### PR DESCRIPTION
There are some cases where reportData.results[0] could be undefined

This is related to https://github.com/LironEr/cypress-mochawesome-reporter/issues/217


<img width="1205" alt="image" src="https://github.com/user-attachments/assets/96a6a33d-ef9d-4610-92ae-1009fb026911" />
